### PR TITLE
use aarch64/M1 compatible base image; explain why JDK 11.0.10; upgrade agent to 7.11.1

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -3,11 +3,11 @@ FROM openjdk:11.0.10-jre
 WORKDIR /tmp
 USER root
 COPY spring-petclinic-2.7.3.jar app.jar
-RUN wget --quiet https://download.newrelic.com/newrelic/java-agent/newrelic-agent/7.11.0/newrelic-agent-7.11.0.jar
+RUN wget --quiet https://download.newrelic.com/newrelic/java-agent/newrelic-agent/7.11.1/newrelic-agent-7.11.1.jar
 COPY newrelic.yml /tmp
 ENV NEW_RELIC_LOG_FILE_NAME="STDOUT"
-ENTRYPOINT ["java","-javaagent:/tmp/newrelic-agent-7.11.0.jar","-Djdk.tls.server.protocols=TLSv1","-Djdk.tls.client.protocols=TLSv1","-jar","/tmp/app.jar"]
+ENTRYPOINT ["java","-javaagent:/tmp/newrelic-agent-7.11.1.jar","-Djdk.tls.server.protocols=TLSv1","-Djdk.tls.client.protocols=TLSv1","-jar","/tmp/app.jar"]
 # TLS DEBUG: very verbose
-#ENTRYPOINT ["java","-javaagent:/tmp/newrelic-agent-7.11.0.jar","-Djdk.tls.server.protocols=TLSv1","-Djdk.tls.client.protocols=TLSv1","-Djavax.net.debug=all","-jar","/tmp/app.jar"]
+#ENTRYPOINT ["java","-javaagent:/tmp/newrelic-agent-7.11.1.jar","-Djdk.tls.server.protocols=TLSv1","-Djdk.tls.client.protocols=TLSv1","-Djavax.net.debug=all","-jar","/tmp/app.jar"]
 # happy-path uses JVM default of TLSv1.2
-#ENTRYPOINT ["java","-javaagent:/tmp/newrelic-agent-7.11.0.jar","-jar","/tmp/app.jar"]
+#ENTRYPOINT ["java","-javaagent:/tmp/newrelic-agent-7.11.1.jar","-jar","/tmp/app.jar"]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,9 +1,13 @@
-FROM openjdk:12-ea-13-jdk-oraclelinux7
+# JDK 11.0.10 is intentional; this version still permits TLSv1 and TLSv1.1
+FROM openjdk:11.0.10-jre
 WORKDIR /tmp
 USER root
 COPY spring-petclinic-2.7.3.jar app.jar
-RUN yum install -y wget
-RUN wget https://download.newrelic.com/newrelic/java-agent/newrelic-agent/7.10.0/newrelic-agent-7.10.0.jar
-ADD newrelic.yml /tmp
+RUN wget --quiet https://download.newrelic.com/newrelic/java-agent/newrelic-agent/7.11.0/newrelic-agent-7.11.0.jar
+COPY newrelic.yml /tmp
 ENV NEW_RELIC_LOG_FILE_NAME="STDOUT"
-ENTRYPOINT ["java","-javaagent:/tmp/newrelic-agent-7.10.0.jar","-Djdk.tls.server.protocols=TLSv1","-Djdk.tls.client.protocols=TLSv1","-jar","/tmp/app.jar"]
+ENTRYPOINT ["java","-javaagent:/tmp/newrelic-agent-7.11.0.jar","-Djdk.tls.server.protocols=TLSv1","-Djdk.tls.client.protocols=TLSv1","-jar","/tmp/app.jar"]
+# TLS DEBUG: very verbose
+#ENTRYPOINT ["java","-javaagent:/tmp/newrelic-agent-7.11.0.jar","-Djdk.tls.server.protocols=TLSv1","-Djdk.tls.client.protocols=TLSv1","-Djavax.net.debug=all","-jar","/tmp/app.jar"]
+# happy-path uses JVM default of TLSv1.2
+#ENTRYPOINT ["java","-javaagent:/tmp/newrelic-agent-7.11.0.jar","-jar","/tmp/app.jar"]


### PR DESCRIPTION
`openjdk:12-ea-13-jdk-oraclelinux7` won't run on aarch64 (and thus not on Apple M1), so the switch to `openjdk:11.0.10-jre` will let users build and run on those platforms.